### PR TITLE
Npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "curl",
+    "version": "0.6.3",
+    "description": "A small, fast module and resource loader with dependency management. (AMD, CommonJS Modules/1.1, CSS, HTML, etc.)",
+    "keywords": ["curl", "cujo", "amd"],
+    "licenses": [
+        {
+            "type": "MIT",
+            "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+    ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/cujojs/curl"
+        }
+    ],
+    "bugs": "https://github.com/cujojs/curl/issues",
+    "maintainers": [
+        {
+            "name": "John Hann",
+            "web": "http://unscriptable.com"
+        },
+        {
+            "name": "Brian Cavalier",
+            "web": "http://hovercraftstudios.com"
+        }
+    ],
+    "main": "./src/curl",
+    "directories": {
+        "test": "test"
+    }
+}


### PR DESCRIPTION
Stub package.json for npm deployments that allows other modules to load curl via npm and a URL to the GitHub tarball.
