### PR TITLE
check for var type on fixAndPushPaths to avoid safari 6 strictness

### DIFF
--- a/src/curl.js
+++ b/src/curl.js
@@ -430,7 +430,9 @@ var window;
 					data = coll[name];
 					// grab the package id, if specified. default to
 					// property name.
-					data.name = data['id'] || data['name'] || name;
+          if(typeof(data) == 'object'){
+            data.name = data['id'] || data['name'] || name;
+          }
 					currCfg = newCfg;
 					// don't remove `|| name` since data may be a string, not an object
 					parts = pluginParts(removeEndSlash(data.name || name));


### PR DESCRIPTION
While testing stuff on Safari 6, we've found out that it is a bit more strict and it doesn't like if you try to assign a property to a string, while other browsers seem to fail silently.
