### PR TITLE
Fix building on systems where /bin/sh is not bash

### DIFF
--- a/bin/make.sh
+++ b/bin/make.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # get optional optimization instruction
 opt=$1


### PR DESCRIPTION
Set bash as the interpreter for make.sh. This allows make.sh to run on systems where /bin/sh is is not a symlink for bash (most non-GNU/Linux POSIX systems and some Linux distributions)
