### PR TITLE
Use newer sourceURL pragma in cjsm11

### DIFF
--- a/src/curl/loader/cjsm11.js
+++ b/src/curl/loader/cjsm11.js
@@ -43,7 +43,7 @@ define(/*=='curl/loader/cjsm11',==*/ ['../plugin/_fetchText', 'curl/_privileged'
 	checkToAddJsExt = priv['core'].checkToAddJsExt;
 
 	function wrapSource (source, resourceId, fullUrl) {
-		var sourceUrl = fullUrl ? '/*\n////@ sourceURL=' + fullUrl.replace(/\s/g, '%20') + '.js\n*/' : '';
+		var sourceUrl = fullUrl ? '/*\n////# sourceURL=' + fullUrl.replace(/\s/g, '%20') + '.js\n*/' : '';
 		return "define('" + resourceId + "'," +
 			"['require','exports','module'],function(require,exports,module){" +
 			source + "\n});\n" + sourceUrl + "\n";


### PR DESCRIPTION
Fixes the warning `SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead` in Firefox
