### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
 	"version": "0.8.12",
 	"description": "curl.js is small, fast, extensible module loader that handles AMD, CommonJS Modules/1.1, CSS, HTML/text, and legacy scripts.",
 	"keywords": ["curl", "cujo", "amd", "loader", "module", "commonjs", "css", "html", "json"],
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	],
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/cujojs/curl"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/