### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
 	"name": "curl",
 	"moduleType": [ "amd", "node" ],
 	"main": "./src/curl.js",
-	"version": "0.8.12",
 	"description": "curl.js is small, fast, extensible module loader that handles AMD, CommonJS Modules/1.1, CSS, HTML/text, and legacy scripts.",
 	"ignore": ["bin", "docs", "test"]
 }


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property