### PR TITLE
Allow add cross origin attribute on the script tags

### DIFF
--- a/src/curl.js
+++ b/src/curl.js
@@ -544,6 +544,7 @@
 			if ('dontAddFileExt' in cfg || cfg.dontAddFileExt) {
 				cfg.dontAddFileExt = new RegExp(cfg['dontAddFileExt'] || cfg.dontAddFileExt);
 			}
+			if ('crossorigin' in cfg) cfg.crossorigin = cfg['crossorigin'];
 
 			prevCfg = userCfg;
 			newCfg = beget(prevCfg, cfg);
@@ -729,6 +730,7 @@
 			el.charset = 'utf-8';
 			el.async = !def.order;
 			el.src = def.url;
+			if (def.config.crossorigin) el.crossOrigin = def.config.crossorigin;
 
 			// loading will start when the script is inserted into the dom.
 			// IE will load the script sync if it's in the cache, so

--- a/test/crossorigin.html
+++ b/test/crossorigin.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>crossorigin script</title>
+
+<script src="../src/curl.js" type="text/javascript"></script>
+<!--<script src="../dist/curl-kitchen-sink/curl.js" type="text/javascript"></script>-->
+
+<script type="text/javascript">
+
+	curl({
+			crossorigin: 'anonymous',
+			paths: {
+				curl: '../src/curl/',
+				aView: 'stuff/aView'
+			}
+		},
+		[
+			'aView/controller'
+		]
+	).then(
+		function (aView) {
+			var isScriptWithAttr = false,
+				scripts = document.getElementsByTagName('script');
+			for (var i = scripts.length; i--;) {
+				if (scripts[i].src.indexOf('stuff/aView/controller.js') > -1 && scripts[i].crossOrigin === 'anonymous') {
+				  isScriptWithAttr = true;
+				}
+			}
+			if (isScriptWithAttr) {
+				write('SUCCESS: script loaded with cross origin attribute');
+			} else {
+				write('FAILED: script has not the correct attribute');
+			}
+		},
+		function (ex) {
+			write('FAILED: should load correctly the file - ' + ex.message);
+		}
+	);
+
+function write (msg) {
+  document.body.appendChild(document.createElement('div')).innerHTML = msg;
+}
+
+
+</script>
+
+</head>
+<body>
+
+<p id="test"></p>
+
+</body>
+</html>


### PR DESCRIPTION
Allow add cross origin attribute on the script tags so it allows in certain scenarios the configure the CORS per request

https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes